### PR TITLE
added year_num() function: process from R-Instat to extract year from a date

### DIFF
--- a/opencdms/process/r-instat/date_components.py
+++ b/opencdms/process/r-instat/date_components.py
@@ -1,0 +1,59 @@
+from io import BytesIO
+import logging
+import os
+import rpy2.robjects as ro
+from rpy2.rinterface_lib.callbacks import logger as rpy2_logger
+from rpy2.robjects import pandas2ri
+from rpy2.robjects.conversion import localconverter
+from rpy2.robjects.packages import importr
+import numpy as np
+import time
+
+# dates, a column of dates to extract the year from
+# Question: what format will this come in from the database?
+# start_month, the month (1 to 12) to start the year in. Default is 1 to start on 1 January.
+# e.g. start_month = 8 defines a year from 1 August to 31 July.
+# In such cases year_num returns the calendar year of the beginning of the year 
+# e.g. year_num(["2020/08/10", "2021/01/20"], start_month = 8) = c(2020, 2020)  
+def year_num(dates, start_month = 1):
+    # Display errors from R, but not warnings
+    rpy2_logger.setLevel(logging.ERROR)
+
+    r = ro.r
+
+    script = os.path.join(
+        os.path.dirname(__file__),
+        'yday_366.r',
+    )
+    r.source(script)
+
+    base = importr("base")
+    # This may need to change depending on the format of the dates parameter.
+    # The following may be an alternative:
+    # _dates = ro.vectors.DateVector(dates)
+    _dates = base.as_Date(dates)
+    _start_month = ro.vectors.IntVector([start_month])
+
+    ro.globalenv['dates'] = _dates
+    ro.globalenv['start_month'] = start_month
+
+    r('''
+
+    library("lubridate")
+    if (!start_month %in% 1:12) stop("start_month must be an integer between 1 and 12. ", start_month, " is invalid.")
+    year_col <- lubridate::year(dates)
+    if (start_month > 1) {
+        # Using a leap year as year to ensure consistent day of year across years.
+        start_doy <- lubridate::yday(as.Date(paste("2000", start_month, 1), format = "%Y %m %d"))
+        doy_col <- as.integer(yday_366(dates))
+        s_doy <- doy_col - start_doy + 1
+        s_year <- year_col
+        s_year[s_doy < 1] <- year_col[s_doy < 1] - 1
+        year_col <- s_year
+    }
+
+    ''')
+    year_data = ro.globalenv['year_col']
+    # Is this the correct Python structure to return?
+    year_data = np.array(year_data)
+    return year_data

--- a/opencdms/process/r-instat/yday_366.r
+++ b/opencdms/process/r-instat/yday_366.r
@@ -1,0 +1,6 @@
+yday_366 <- function(date) {
+  temp_doy <- lubridate::yday(date)
+  temp_leap <- lubridate::leap_year(date)
+  temp_doy[(!is.na(temp_doy)) & temp_doy > 59 & (!temp_leap)] <- 1 + temp_doy[(!is.na(temp_doy)) & temp_doy > 59 & (!temp_leap)]
+  return(temp_doy)
+}


### PR DESCRIPTION
- added `date_components.py` file containing a single function `year_num()` following a similar structure to [climatol windrose()](https://github.com/opencdms/pyopencdms/blob/main/opencdms/process/climatol/__init__.py) to call R script and retrieve output
- added `yday_366.r` containing an R function required by `year_num()`

@iedwards some general questions arising from this PR:

- What is the correct folder and file structure for the processes to be created? e.g. a folder for each process, or each group like R-Instat,? Should files contain a single function?
- Should we be using a documentation convention such as docstrings to document Python functions created?
- In what format will data be passed in to processes? e.g. `obs` for `windrose()` or `dates` for `year_num()`. Will the processes need to deal with multiple formats or will this be standardised?
- In what format should functions that return data be in? Here I have used `np.array` to return a numeric array of years.
- There seems to be multiple ways of using the `rpy2` package to interact with R. For example, I used a different way of converting a Python array into an R compatible array than used in [climatol windrose()](https://github.com/opencdms/pyopencdms/blob/main/opencdms/process/climatol/__init__.py#L24)

Happy to make separate issues for these questions to allow discussion.